### PR TITLE
Switch to WebGL2, hardcoded fullscreen vertices in shader, highp prec…

### DIFF
--- a/src/lib/openGL.ts
+++ b/src/lib/openGL.ts
@@ -9,7 +9,7 @@ type InitFunction = (
 ) => ProgramInfo;
 
 export const initialiseWebGL: InitFunction = (canvas,vertexShaderSource,fragmentShaderSource,vertexData) => { 
-  const gl = canvas.getContext("webgl");
+  const gl = canvas.getContext("webgl2");
   if (!gl) {
     throw("no gl instance found")
   }
@@ -27,30 +27,29 @@ export const initialiseWebGL: InitFunction = (canvas,vertexShaderSource,fragment
   if (!program) {
   throw("no gl instance found")
   }
-  const positionBuffer = gl.createBuffer();
-  gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
-  gl.bufferData(
-    gl.ARRAY_BUFFER,
-    new Float32Array(vertexData),
-    gl.STATIC_DRAW
-  );
 
   gl.shaderSource(vertexShader, vertexShaderSource);
   gl.compileShader(vertexShader);
 
+  let success = gl.getShaderParameter(vertexShader, gl.COMPILE_STATUS);
+  if (!success) {
+    throw "Could not compile vertex shader:" + gl.getShaderInfoLog(vertexShader);
+  }
+
   gl.shaderSource(fragmentShader, fragmentShaderSource);
   gl.compileShader(fragmentShader);
+
+  success = gl.getShaderParameter(fragmentShader, gl.COMPILE_STATUS);
+  if (!success) {
+    throw "Could not compile fragment shader:" + gl.getShaderInfoLog(fragmentShader);
+  }
 
   gl.attachShader(program, vertexShader);
   gl.attachShader(program, fragmentShader);
 
   gl.linkProgram(program);
-
-  const positionLocation = gl.getAttribLocation(program, `position`);
-  gl.enableVertexAttribArray(positionLocation);
-  gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer);
-  gl.vertexAttribPointer(positionLocation, 3, gl.FLOAT, false, 0, 0);
   gl.useProgram(program);
+  
   const resolutionLoc = gl.getUniformLocation(program, "resolution");
   const locationLoc = gl.getUniformLocation(program, "location");
   const mousePosLoc = gl.getUniformLocation(program, "mousePos")

--- a/src/lib/shaders.ts
+++ b/src/lib/shaders.ts
@@ -1,11 +1,23 @@
-export const vertexShaderSource = `
-  attribute vec3 position;
-  void main() {
-    gl_Position = vec4(position, 1.0);
-  }
+export const vertexShaderSource = `#version 300 es
+
+vec2 vertices[6] = vec2[6](
+	vec2(-1.0, -1.0),
+	vec2(1.0, 1.0),
+	vec2(1.0, -1.0),
+	vec2(-1.0, -1.0),
+	vec2(1.0, 1.0),
+	vec2(-1.0, 1.0)
+);
+
+void main() {
+gl_Position = vec4(vertices[gl_VertexID], 0.0, 1.0);
+}
 `;
 
-export const fragmentShaderSource = `precision mediump float;
+export const fragmentShaderSource = `#version 300 es
+
+precision highp float;
+
 uniform ivec2 resolution;
 uniform vec2 location;
 uniform vec2 mousePos;
@@ -13,6 +25,8 @@ uniform int fractalType;
 uniform bool isJuliaModeEnabled;
 const int iterations = 200;
 uniform float zoom;
+
+out vec4 FragColor;
 
 const int mandelbrot = 0;
 const int burningship = 1;
@@ -78,7 +92,7 @@ void main() {
     fragColor += vec3(float(fractal(vec2(0,0.5))) / float(iterations));
     fragColor += vec3(float(fractal(vec2(0.5,0.5))) / float(iterations));
     fragColor /= 4.0;
-    gl_FragColor = vec4(fragColor, 1.0);
+    FragColor = vec4(fragColor, 1.0);
 
 }
 `


### PR DESCRIPTION
Features
* Now using WebGL2 context and GLSL ES 300
* Instead of using vertex buffer and attributes, fullscreen quad vertices are hardcoded in the vertex shader for simplicity
* Added error checking for shader compilation
* Shaders now using high precision floats